### PR TITLE
[#2] [chore] Configure CI on Github Actions

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 DOCKER_REGISTRY_HOST=docker.io
-DOCKER_IMAGE=nimblehq/google_crawler
+DOCKER_IMAGE=htooeainlwin12/google_crawler
 BRANCH_TAG=latest
 PORT=80
 CI=false

--- a/.github/workflows/deploy_heroku.yml
+++ b/.github/workflows/deploy_heroku.yml
@@ -14,9 +14,9 @@ on:
 
 env:
   DOCKER_REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}
-  DOCKER_REGISTRY_USERNAME: ${{ github.repository_owner }}
+  DOCKER_REGISTRY_USERNAME: htooeainlwin12
   DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
-  DOCKER_IMAGE: ${{ github.repository }}
+  DOCKER_IMAGE: htooeainlwin12/google-crawler
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         run: docker-compose pull test || true
 
       - name: Run codebase test
-        run: docker-compose run test bundle exec rspec spec/codebase/codebase_spec.rb --format progress
+        run: docker-compose run test -e DISABLE_SPRING=1 bundle exec rspec spec/codebase/codebase_spec.rb --format progress
 
   unit_tests:
     name: Unit tests
@@ -98,7 +98,7 @@ jobs:
         run: docker-compose pull test || true
 
       - name: Run unit tests
-        run: docker-compose run test bundle exec rspec --exclude-pattern "spec/systems/**/*_spec.rb, spec/codebase/codebase_spec.rb" --profile --format progress
+        run: docker-compose run test -e DISABLE_SPRING=1 bundle exec rspec --exclude-pattern "spec/systems/**/*_spec.rb, spec/codebase/codebase_spec.rb" --profile --format progress
 
       - name: Upload tests coverage artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ on:
 env:
   DANGER_GITHUB_API_TOKEN: ${{ github.token }}
   DOCKER_REGISTRY_HOST: ${{ secrets.DOCKER_REGISTRY_HOST }}
-  DOCKER_REGISTRY_USERNAME: ${{ github.repository_owner }}
+  DOCKER_REGISTRY_USERNAME: htooeainlwin12
   DOCKER_REGISTRY_TOKEN: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
-  DOCKER_IMAGE: ${{ github.repository }}
+  DOCKER_IMAGE: htooeainlwin12/google-crawler
   NODE_VERSION: 16
 
   # Set the default docker-compose file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,7 +184,7 @@ jobs:
         run: yarn
 
       - name: Run Undercover
-        run: bundle exec undercover-report
+        run: bundle exec undercover-report -l /home/runner/work/google-crawler/google-crawler/coverage/lcov/google_crawler.lcov
 
       - name: Run Danger
         run: bundle exec danger

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         run: docker-compose pull test || true
 
       - name: Run codebase test
-        run: docker-compose run test -e DISABLE_SPRING=1 bundle exec rspec spec/codebase/codebase_spec.rb --format progress
+        run: docker-compose run test bundle exec rspec spec/codebase/codebase_spec.rb --format progress
 
   unit_tests:
     name: Unit tests
@@ -98,7 +98,7 @@ jobs:
         run: docker-compose pull test || true
 
       - name: Run unit tests
-        run: docker-compose run test -e DISABLE_SPRING=1 bundle exec rspec --exclude-pattern "spec/systems/**/*_spec.rb, spec/codebase/codebase_spec.rb" --profile --format progress
+        run: docker-compose run test bundle exec rspec --exclude-pattern "spec/systems/**/*_spec.rb, spec/codebase/codebase_spec.rb" --profile --format progress
 
       - name: Upload tests coverage artifact
         uses: actions/upload-artifact@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
     no_proxy_fix (0.1.2)
     nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
+      racc (~> 1.4)
     octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -457,6 +459,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   awesome_print

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class HomeController < ApplicationController
+  def index; end
+end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,0 +1,4 @@
+h1 Hello from crawler
+
+#content
+  p This example shows you how a basic Slim file looks.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
-  # root "articles#index"
+  root "home#index"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+require 'support/simplecov'
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 
-require 'spec_helper'
 require 'rspec/rails'
 require 'json_matchers/rspec'
 require 'pundit/rspec'

--- a/spec/routing/home_routing_spec.rb
+++ b/spec/routing/home_routing_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HomeController do
+  it 'route to #index' do
+    expect(get('/')).to route_to('home#index')
+  end
+end


### PR DESCRIPTION
close #2 

## What happened 👀

Making sure automation tests are able to run for every PR.

## Insight 📝
- Replace the configuration with my own docker.
- I need to specify the undercover report path via `bundle exec undercover-report -l /home/runner/work/google-crawler/google-crawler/coverage/lcov/google_crawler.lcov` for the following silent error. As you can see in [here](https://github.com/htoo-eain-lwin/google-crawler/actions/runs/5746570247). Under Run Ranger -> Run Undercover. It's silently failing without causing any issue. 
I can by pass via above solution but still trying to figure out how to solve in our rails template.

```
Run bundle exec undercover-report
##[debug]/usr/bin/bash -e /home/runner/work/_temp/f688f809-33cc-4278-85fb-6ab47e5d20a4.sh
/home/runner/work/google-crawler/google-crawler/vendor/bundle/ruby/3.2.0/gems/undercover-0.4.6/lib/undercover.rb:32:in `initialize': No such file or directory @ rb_sysopen - /home/runner/work/google-crawler/google-crawler/coverage/lcov/google-crawler.lcov (Errno::ENOENT)
	from /home/runner/work/google-crawler/google-crawler/vendor/bundle/ruby/3.2.0/gems/undercover-0.4.6/lib/undercover.rb:32:in `open'
```

## Proof Of Work 📹

https://github.com/htoo-eain-lwin/google-crawler/actions/runs/5746570247
